### PR TITLE
removed white spaces from match regex to allow to mark phrases that contain brackets

### DIFF
--- a/mark-the-words.js
+++ b/mark-the-words.js
@@ -87,7 +87,7 @@ H5P.MarkTheWords = (function ($, Question) {
       if (node instanceof Text) {
         var text = $(node).text();
         var selectableStrings = text.replace(/(&nbsp;|\r\n|\n|\r)/g, ' ')
-          .match(/ \*[^\*]+\* |[^\s]+/g);
+            .match(/\*[^\*]+\*|[^\s]+/g);
 
         if (selectableStrings) {
           selectableStrings.forEach(function (entry) {


### PR DESCRIPTION
phrases which should not be correct can be realized by replacing white spaces with "&nbsp" (no colon!)

 Changes to be committed:
	modified:   mark-the-words.js