### PR TITLE
Make seperated terms as word selectable

### DIFF
--- a/scripts/mark-the-words.js
+++ b/scripts/mark-the-words.js
@@ -93,7 +93,7 @@ H5P.MarkTheWords = (function ($, Question, Word, KeyboardNav, XapiGenerator) {
       if (node instanceof Text) {
         var text = $(node).text();
         var selectableStrings = text.replace(/(&nbsp;|\r\n|\n|\r)/g, ' ')
-          .match(/ \*[^\* ]+\* |[^\s]+/g);
+          .match(/ \*[^\*]+\* |[^\s]+/g);
 
         if (selectableStrings) {
           selectableStrings.forEach(function (entry) {


### PR DESCRIPTION
There are words, that are seperated by spaces like "cat content" or "high speed camera". So, it should be possible to bracket those multi word terms with *'s as well.