### PR TITLE
Make seperated terms as word selectable

### DIFF
--- a/language/.en.json
+++ b/language/.en.json
@@ -10,8 +10,8 @@
       "placeholder": "This is an answer: *answer*.",
       "description": "",
       "important": {
-        "description": "<ul><li>Marked words are added with an asterisk (*).</li><li>Asterisks can be added within marked words by adding another asterisk, *correctword*** =&gt; correctword*.</li></ul>",
-        "example": "The correct words are marked like this: *correctword*, an asterisk is written like this: *correctword***."
+        "description": "<ul><li>Marked words are added with an asterisk (*).</li><li>Asterisks can be added within marked words by adding another asterisk, *correctword*** =&gt; correctword*.</li><li>A phrase or a term consisting of two or more consecutive words can be marked as *correct__word* &gt; correct word.</li></ul>",
+        "example": "The correct words are marked like this: *correct__words*, an asterisk is written like this: *correctword***."
       }
     },
     {

--- a/language/.en.json
+++ b/language/.en.json
@@ -10,7 +10,7 @@
       "placeholder": "This is an answer: *answer*.",
       "description": "",
       "important": {
-        "description": "<ul><li>Marked words are added with an asterisk (*).</li><li>Asterisks can be added within marked words by adding another asterisk, *correctword*** =&gt; correctword*.</li><li>A phrase or a term consisting of two or more consecutive words can be marked as *correct__word* &gt; correct word.</li></ul>",
+        "description": "<ul><li>Marked words are added with an asterisk (*).</li><li>Asterisks can be added within marked words by adding another asterisk, *correctword*** =&gt; correctword*.</li><li>For a phrase or a term consisting of two or more consecutive words please substitute the separating spaces with __ (2 underbars) like: *correct__word* &gt; correct word.</li></ul>",
         "example": "The correct words are marked like this: *correct__words*, an asterisk is written like this: *correctword***."
       }
     },

--- a/language/de.json
+++ b/language/de.json
@@ -10,7 +10,7 @@
       "placeholder": "Das ist eine Antwort: *Antwort*.",
       "description": "",
       "important": {
-        "description": "<ul><li>Die zu findenden Wörter werden mit einem Sternchen (*) markiert.</li><li>Soll in einem zu findenden Wort ein Sternchen verwendet werden, gibt man ** ein.</li></ul>",
+        "description": "<ul><li>Die zu findenden Wörter werden mit einem Sternchen (*) markiert.</li><li>Soll in einem zu findenden Wort ein Sternchen verwendet werden, gibt man ** ein.</li><li>Sollen zwei oder mehrere aufeinander folgende Wörter als Phrase genutzt werden, gibt man statt der trennenden Leerzeichen __ (2 Unterstriche) ein.</li></ul>",
         "example": "Richtige Wörter werden wie folgt markiert: *richtigeswort*. Ein Sternchen in einem richtigen Wort auf diese Weise: *richtiges**Wort*."
       }
     },

--- a/scripts/mark-the-words.js
+++ b/scripts/mark-the-words.js
@@ -93,17 +93,18 @@ H5P.MarkTheWords = (function ($, Question, Word, KeyboardNav, XapiGenerator) {
       if (node instanceof Text) {
         var text = $(node).text();
         var selectableStrings = text.replace(/(\r\n|\n|\r)/g, ' ').replace(/(&nbsp;|&#32;)/g, '__')
-          .match(/ \*[^\* ]+\* |[^\s]+/g).replace(/(__)/g, ' ');
+          .match(/ \*[^\* ]+\* |[^\s]+/g);
 
         if (selectableStrings) {
           selectableStrings.forEach(function (entry) {
-            entry = entry.trim();
-
+            
             // Words
-            if (html) {
+            if ((html) && (entry.substring(0, 1) == ' ')) {
               // Add space before
               html += ' ';
             }
+            
+            entry = entry.replace(/(__)/g, ' ').trim();                      
 
             // Remove prefix punctuations from word
             var prefix = entry.match(/^[\[\({⟨¿¡“"«„]+/);

--- a/scripts/mark-the-words.js
+++ b/scripts/mark-the-words.js
@@ -92,8 +92,8 @@ H5P.MarkTheWords = (function ($, Question, Word, KeyboardNav, XapiGenerator) {
 
       if (node instanceof Text) {
         var text = $(node).text();
-        var selectableStrings = text.replace(/(&nbsp;|\r\n|\n|\r)/g, ' ')
-          .match(/ \*[^\* ]+\* |[^\s]+/g);
+        var selectableStrings = text.replace(/(\r\n|\n|\r)/g, ' ').replace(/(&nbsp;|&#32;)/g, '__')
+          .match(/ \*[^\* ]+\* |[^\s]+/g).replace(/(__)/g, ' ');
 
         if (selectableStrings) {
           selectableStrings.forEach(function (entry) {


### PR DESCRIPTION
This is a follow-up from PR #74
There are words, that are seperated by spaces like "cat content" or "high speed camera". So, it should be possible to bracket those multi word terms with *'s as well. therefore, instructional designers SHOULD be able to decide whether words ought to be marked independently or phrases/terms  consisting of multiple words could be selected by one click (with the cost that hovering above will tell students a correct answer).

There has been a long ongoing discussion and a quick&dirty-hack by replacing the space by &#32 ; however the character &will be parsed to HTML-entities now and the "hack" is not working anylonger.

This proposal introduces a replacement of __ (2 underbars) for this scenario. Also, &nbsp and &#32 and &#160. Changed English and German language pack accordingly.

Also fixed minor display glitch that prints a space before interpunction when there is a HTML tag right before this.

