### PR TITLE
Fix cursor suggesting clickable item after checking

### DIFF
--- a/styles/mark-the-words.css
+++ b/styles/mark-the-words.css
@@ -34,12 +34,12 @@
   white-space: nowrap;
   padding: 0.15em;
   border-radius: 0.25em;
-  cursor: pointer;
   position: relative;
 }
 
 .h5p-mark-the-words .h5p-word-selectable-words:not(.h5p-disable-hover) [role="option"]:hover {
   box-shadow: inset 0px 0px 0px 2px #cee0f4;
+  cursor: pointer;
 }
 
 /* Colors and styling for word selections */


### PR DESCRIPTION
When the `hover` effect for words has been disabled after checking, the hover cursor is still suggesting that a word can be clicked although it can't.

When merged in, this will be fixed by only changing the cursor value to `pointer` if hovering is not disabled.