### PR TITLE
Fix isAnswered state when restoring previous state

### DIFF
--- a/scripts/mark-the-words.js
+++ b/scripts/mark-the-words.js
@@ -620,6 +620,8 @@ H5P.MarkTheWords = (function ($, Question, Word, KeyboardNav, XapiGenerator) {
       if (isNaN(answeredWordIndex) || answeredWordIndex >= self.selectableWords.length || answeredWordIndex < 0) {
         throw new Error('Stored user state is invalid');
       }
+
+      this.isAnswered = true;
       self.selectableWords[answeredWordIndex].setSelected();
     });
   };

--- a/scripts/mark-the-words.js
+++ b/scripts/mark-the-words.js
@@ -621,7 +621,7 @@ H5P.MarkTheWords = (function ($, Question, Word, KeyboardNav, XapiGenerator) {
         throw new Error('Stored user state is invalid');
       }
 
-      this.isAnswered = true;
+      self.isAnswered = true;
       self.selectableWords[answeredWordIndex].setSelected();
     });
   };


### PR DESCRIPTION
Currently, when restoring a previous state that holds marked words, the `isAnswered` property is not set to `true` although the user must have answered the question before.

When merged in, the `isAnswered` state will be set to `true` if the user restores a previous session and the previous state holds marked words.