### PR TITLE
Allow for custom number of Lines to be selected

### DIFF
--- a/scripts/mark-the-words.js
+++ b/scripts/mark-the-words.js
@@ -30,6 +30,7 @@ H5P.MarkTheWords = (function ($, Question, Word, KeyboardNav, XapiGenerator) {
       textField: "This is a *nice*, *flexible* content type.",
       overallFeedback: [],
       behaviour: {
+        numLines: null,
         enableRetry: true,
         enableSolutionsButton: true,
         enableCheckButton: true,
@@ -198,6 +199,10 @@ H5P.MarkTheWords = (function ($, Question, Word, KeyboardNav, XapiGenerator) {
     self.selectableWords = [];
     self.answers = 0;
 
+    // If NumLines Parameter is properly set this will select a random set of paragraphs from the base textField parameter	  
+    if (!(this.params.behaviour.numLines <= 2 || this.params.behaviour.numLines >= this.params.textField.split('\n\n').length)) {
+      this.params.textField = this.params.textField.split('\n\n').sort(() => Math.random() - 0.5).slice(0, this.params.behaviour.numLines).join('\n\n')
+    }
     // Wrapper
     var $wordContainer = $('<div/>', {
       'class': 'h5p-word-selectable-words',

--- a/semantics.json
+++ b/semantics.json
@@ -179,6 +179,15 @@
     "optional": true,
     "fields": [
       {
+        "name": "numLines",
+        "type": "number",
+        "label": "Number of Lines to use",
+        "description": "Setting this to a number less than the number of paragraphs and greater than 1 will make it randomly select paragraphs each time",
+        "importance": "low",
+        "optional": true,
+        "min": 2
+      },
+      {
         "name": "enableRetry",
         "type": "boolean",
         "label": "Enable \"Retry\"",


### PR DESCRIPTION
This small patch to the Mark-the-words content type allows users to select a custom number of paragraphs to be used each time the quiz is taken. It incorporates logic similar to that of the numCardsToUse parameter in the memory game content type. This is very useful for users who have a large block of text they want to convert to mark-the-words quizzes but who don't want to have to make numerous amounts of quizzes.